### PR TITLE
Set `module` option of TypeScript to `ESNext`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts"],
   "compilerOptions": {
     "target": "es2020",
-    "module": "es2020",
+    "module": "ESNext",
     "moduleResolution": "node",
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
雑に top-level await したい