### PR TITLE
Refactor docgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: node_modules clear create-dist-dir
 
 .PHONY: docgen
 docgen: node_modules
-	node --loader ts-node/esm bin/docgen.ts
+	node --loader ts-node/esm bin/docgen/index.ts
 	@make format
 
 .PHONY: typecheck

--- a/bin/docgen.ts
+++ b/bin/docgen.ts
@@ -1,7 +1,5 @@
-import { parse, tokenizers } from "comment-parser"
 import * as A from "fp-ts/lib/Array.js"
 import { pipe } from "fp-ts/lib/function.js"
-import * as O from "fp-ts/lib/Option.js"
 import * as Ord from "fp-ts/lib/Ord.js"
 import * as string from "fp-ts/lib/string.js"
 import { readFile, writeFile } from "fs/promises"
@@ -10,45 +8,14 @@ import path from "path"
 
 import { FileProperties } from "../types"
 
+import { parseComments } from "./docgen/parseComments"
+
 const getFiles = (): string[] => {
   try {
     return glob.sync(path.resolve("src", "*.ts"))
   } catch (err) {
     console.error(err)
     return []
-  }
-}
-
-export const parseComments = async (
-  filepath: string
-): Promise<O.Option<FileProperties>> => {
-  try {
-    const file = await readFile(filepath)
-    const lines = file.toString()
-    const commentString = lines.slice(
-      lines.indexOf("/**"),
-      lines.indexOf("*/") + 2
-    )
-
-    const blocks = parse(commentString, {
-      tokenizers: [tokenizers.tag(), tokenizers.description("compact")],
-    })
-    if (blocks.length === 0) return O.none
-
-    const specs = blocks[0].tags
-    const titleSpec = specs.find(({ tag }) => tag === "title")
-    const descriptionSpec = specs.find(({ tag }) => tag === "description")
-
-    if (!titleSpec) return O.none
-
-    return O.some({
-      filename: path.basename(filepath),
-      title: titleSpec.description,
-      description: descriptionSpec?.description,
-    })
-  } catch (err) {
-    console.error(err)
-    return O.none
   }
 }
 

--- a/bin/docgen.ts
+++ b/bin/docgen.ts
@@ -8,11 +8,7 @@ import { readFile, writeFile } from "fs/promises"
 import glob from "glob"
 import path from "path"
 
-type FileProperties = {
-  filename: string
-  title: string
-  description?: string
-}
+import { FileProperties } from "../types"
 
 const getFiles = (): string[] => {
   try {

--- a/bin/docgen/index.ts
+++ b/bin/docgen/index.ts
@@ -2,13 +2,13 @@ import * as A from "fp-ts/lib/Array.js"
 import { pipe } from "fp-ts/lib/function.js"
 import * as Ord from "fp-ts/lib/Ord.js"
 import * as string from "fp-ts/lib/string.js"
-import { readFile, writeFile } from "fs/promises"
 import glob from "glob"
 import path from "path"
 
 import { FileProperties } from "../../types"
 
 import { parseComments } from "./parseComments.js"
+import { generateMdFileEntry, updateReadme } from "./readmeMarkdown.js"
 
 const getFiles = (): string[] => {
   try {
@@ -17,34 +17,6 @@ const getFiles = (): string[] => {
     console.error(err)
     return []
   }
-}
-
-const generateMdFileEntry = ({
-  filename,
-  title,
-  description,
-}: FileProperties): string => {
-  return `
-### [${title}](https://raw.githubusercontent.com/mkobayashime/bookmarklets/main/dist/${filename.replace(
-    /.ts$/,
-    ".js"
-  )})
-
-${description ?? ""}
-  `.trim()
-}
-
-const updateReadme = async (scriptsMarkdown: string): Promise<void> => {
-  const readme = (await readFile(path.resolve(".", "README.md"))).toString()
-  if (!readme) return
-
-  const readmeCommonPart = readme.slice(
-    0,
-    readme.indexOf("## Scripts") + "## Scripts".length
-  )
-
-  const updatedReadme = readmeCommonPart + "\n\n" + scriptsMarkdown
-  await writeFile(path.resolve("README.md"), updatedReadme)
 }
 
 //

--- a/bin/docgen/index.ts
+++ b/bin/docgen/index.ts
@@ -6,9 +6,9 @@ import { readFile, writeFile } from "fs/promises"
 import glob from "glob"
 import path from "path"
 
-import { FileProperties } from "../types"
+import { FileProperties } from "../../types"
 
-import { parseComments } from "./docgen/parseComments"
+import { parseComments } from "./parseComments.js"
 
 const getFiles = (): string[] => {
   try {

--- a/bin/docgen/parseComments.ts
+++ b/bin/docgen/parseComments.ts
@@ -1,0 +1,39 @@
+import { parse, tokenizers } from "comment-parser"
+import * as O from "fp-ts/lib/Option.js"
+import { readFile } from "fs/promises"
+import path from "path"
+
+import { FileProperties } from "../../types"
+
+export const parseComments = async (
+  filepath: string
+): Promise<O.Option<FileProperties>> => {
+  try {
+    const file = await readFile(filepath)
+    const lines = file.toString()
+    const commentString = lines.slice(
+      lines.indexOf("/**"),
+      lines.indexOf("*/") + 2
+    )
+
+    const blocks = parse(commentString, {
+      tokenizers: [tokenizers.tag(), tokenizers.description("compact")],
+    })
+    if (blocks.length === 0) return O.none
+
+    const specs = blocks[0].tags
+    const titleSpec = specs.find(({ tag }) => tag === "title")
+    const descriptionSpec = specs.find(({ tag }) => tag === "description")
+
+    if (!titleSpec) return O.none
+
+    return O.some({
+      filename: path.basename(filepath),
+      title: titleSpec.description,
+      description: descriptionSpec?.description,
+    })
+  } catch (err) {
+    console.error(err)
+    return O.none
+  }
+}

--- a/bin/docgen/readmeMarkdown.ts
+++ b/bin/docgen/readmeMarkdown.ts
@@ -1,0 +1,32 @@
+import { readFile, writeFile } from "fs/promises"
+import path from "path"
+
+import { FileProperties } from "../../types"
+
+export const generateMdFileEntry = ({
+  filename,
+  title,
+  description,
+}: FileProperties): string => {
+  return `
+### [${title}](https://raw.githubusercontent.com/mkobayashime/bookmarklets/main/dist/${filename.replace(
+    /.ts$/,
+    ".js"
+  )})
+
+${description ?? ""}
+  `.trim()
+}
+
+export const updateReadme = async (scriptsMarkdown: string): Promise<void> => {
+  const readme = (await readFile(path.resolve(".", "README.md"))).toString()
+  if (!readme) return
+
+  const readmeCommonPart = readme.slice(
+    0,
+    readme.indexOf("## Scripts") + "## Scripts".length
+  )
+
+  const updatedReadme = readmeCommonPart + "\n\n" + scriptsMarkdown
+  await writeFile(path.resolve("README.md"), updatedReadme)
+}

--- a/test/hasDocData.test.ts
+++ b/test/hasDocData.test.ts
@@ -4,16 +4,13 @@ import glob from "glob"
 import fs from "node:fs/promises"
 import path, { basename } from "node:path"
 
-import { readFileComments, parseComment } from "../bin/docgen.js"
+import { parseComments } from "../bin/docgen/parseComments.js"
 
 const bookmarklets = glob.sync(path.resolve("src", "*.ts"))
 
 for await (const filepath of bookmarklets) {
   test(`${basename(filepath)} has doc data or docgen-ignored`, async (t) => {
-    const comments = parseComment({
-      comment: await readFileComments(filepath),
-      filename: filepath,
-    })
+    const comments = await parseComments(filepath)
 
     if (O.isSome(comments)) {
       return t.pass()

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,5 @@
+export type FileProperties = {
+  filename: string
+  title: string
+  description?: string
+}


### PR DESCRIPTION
テストが IIFE を持つ `docgen.ts` から `parseComment` を import しているためにテストのつもりが毎回  docgen が実行されていた(!)ので module に切り分ける

- Move `FileProperties` type to `/types` dir
- Unite `readFileComments` and `parseComment` into `parseComments` function
- Move `parseComments` to a separated module
- Move docgen script to `/bin/docgen` dir
- Move `generateMdFileEntry`/`updateReadme` functions to separated module
